### PR TITLE
SSL+camo support!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 postgres/data
+nginx-reverse-proxy.custom
+nerdz_venv/

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "php"]
 	path = php
 	url = https://github.com/nerdzeu/docker-php
+[submodule "camo"]
+	path = camo
+	url = https://github.com/nerdzeu/docker-camo

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ cp nginx-reverse-proxy.custom /etc/nginx/sites-enabled/<yourhost>
 
 On other distros you should put the configuration file where nginx can found it.
 
+To enable SSL, you have to perform the following step:
+
+```sh
+# if you're using a different folder, you may want
+# to update the ssl_certificate_* paths
+#vim /etc/nginx/sites-enabled/<yourhost>
+mkdir /etc/nginx/ssl
+cp nginx/conf/certs/nerdz.* /etc/nginx/ssl/
+```
+In case you don't want SSL, or you already have your own SSL certificates, modify
+every `ssl_certificate` directive with the path to your own SSL certs.
+
+(Note: in a future commit, `autosetup.sh` take care of that too)
+
 After you only have to run docker-composer (it can take a long time if your internet connection is slow).
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ nerdzeu/docker
 # Requirements
 
 - Docker
-- docker-compose
+- virtualenv
 - nginx (on the host)
 
 # Usage
@@ -19,16 +19,27 @@ Enter into the repo (docker) folder.
 ```sh
 cd docker
 ```
+Now, execute
+
+```sh
+. autosetup.sh <yourhost>
+```
+
+`autosetup.sh` will
+
+* automagically create a virtualenv and install docker-compose from the cheese shop (PyPI)
+* create `nginx-reverse-proxy.custom`, which is an ad-hoc modified nginx-reverse-proxy with `<yourhost>` as `server_name`.
+
+Please take your time to carefully review each modification using `git diff` (it works on submodules too, just `cd` into them).
+In `nginx-reverse-proxy.custom`, you should not touch anything but the `server_name` if you find the script did not work.
 
 On Debian you have the `/etc/nginx/sites-enabled/` folder where to put nginx-reverse-proxy.
 
 ```sh
-cp nginx-reverse-proxy /etc/nginx/sites-enabled/<yourhost>
+cp nginx-reverse-proxy.custom /etc/nginx/sites-enabled/<yourhost>
 ```
 
 On other distros you should put the configuration file where nginx can found it.
-
-You _must_ configure the file (the server_name directive of each server block. Do not touch anything else).
 
 After you only have to run docker-composer (it can take a long time if your internet connection is slow).
 
@@ -38,7 +49,7 @@ docker-compose up -d
 
 If you don't want to run the container in detached mode, remove the `-d` (you'll see logs).
 
-Otherwhise you can read the locks running `docker-composer logs`
+Otherwhise you can read the logs running `docker-composer logs`
 
 When the installation is complete (see the logs of the docker_php container, when php-fpm started the setup is completed correctly).
 
@@ -46,4 +57,4 @@ Now you _MUST_ edit `docker/php/env/class/config/index.php` changing SITE_HOST t
 
 Hint: set STATIC_DOMAIN to ''.
 
-If you want you want (or need), you can change every other _HOST contants.
+If you want (or need), you can change every other \_HOST contants.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Enter into the repo (docker) folder.
 ```sh
 cd docker
 ```
+
+## nginx configuration
+
 Now, execute
 
 ```sh
@@ -26,7 +29,6 @@ Now, execute
 ```
 
 `autosetup.sh` will
-
 * automagically create a virtualenv and install docker-compose from the cheese shop (PyPI)
 * create `nginx-reverse-proxy.custom`, which is an ad-hoc modified nginx-reverse-proxy with `<yourhost>` as `server_name`.
 
@@ -41,6 +43,8 @@ cp nginx-reverse-proxy.custom /etc/nginx/sites-enabled/<yourhost>
 
 On other distros you should put the configuration file where nginx can found it.
 
+### Enable SSL on nginx
+
 To enable SSL, you have to perform the following step:
 
 ```sh
@@ -53,7 +57,11 @@ cp nginx/conf/certs/nerdz.* /etc/nginx/ssl/
 In case you don't want SSL, or you already have your own SSL certificates, modify
 every `ssl_certificate` directive with the path to your own SSL certs.
 
-(Note: in a future commit, `autosetup.sh` take care of that too)
+### Apply your modifications to nginx
+
+Now, you can restart your nginx istance. On debian, just run `service nginx restart`. On other platforms, consult your system' man page.
+
+## docker configuration
 
 After you only have to run docker-composer (it can take a long time if your internet connection is slow).
 
@@ -63,12 +71,51 @@ docker-compose up -d
 
 If you don't want to run the container in detached mode, remove the `-d` (you'll see logs).
 
-Otherwhise you can read the logs running `docker-composer logs`
+Otherwhise you can read the logs running `docker-compose logs`
 
-When the installation is complete (see the logs of the docker_php container, when php-fpm started the setup is completed correctly).
+When the installation is complete (see the logs of the docker_php container, when php-fpm started the setup is completed correctly), stop it with `ctrl-c` or `docker-compose stop`.  
+You are now ready for a new round of configuration.
 
-Now you _MUST_ edit `docker/php/env/class/config/index.php` changing SITE_HOST to $yourhost-configured-on-nginx. (otherwise referrer control won't let you do anything).
+## camo configuration
 
-Hint: set STATIC_DOMAIN to ''.
+[Camo](https://github.com/atmos/camo) is a nice proxy to serve HTTP images on HTTPS.  
+It can be configured by environment variables, and they're read from `camo/env` file.
+An example follows.
+```sh
+#put these in a file called `env` inside the camo submodule. 
+export PORT=8081
+export CAMO_KEY=<camokey>
+```
 
-If you want (or need), you can change every other \_HOST contants.
+## Nerdz site configuration
+
+Now you _MUST_ edit `docker/php/env/nerdz.eu/class/config/index.php`:
+
+* change `SITE_HOST` to `$yourhost-configured-on-nginx`   
+  (otherwise referrer control won't let you do anything).
+* change `CAMO_KEY` to `$camokey-configured-in-camo`
+
+If you want (or need), you can change every other \_HOST contants. Please note that, if you did not set up a DNS entry for `STATIC_DOMAIN`, you may want to set it to `''`. If you did it, instead, you may want to set it as `'//static.<yourhost>'`: it will avoid some headaches later.
+
+## Start docker again
+
+Run `docker-compose` again.
+
+```sh
+docker-compose up -d
+```
+
+Now, your system should be up and running. Enjoy your shiny Nerdz installation!
+
+# Troubleshooting
+
+* _Everything went kaboom!_  
+Please get out of Iran and try again.
+
+* _CSS and stuff is not loaded!_  
+Did you try to setup STATIC_DOMAIN to `''` or `'//static.<yourhost>'`?
+
+* _My problem is not listed here!_  
+Please, open an issue in the project issue tracker: we'll be more than happy to help you. In case you did find a solution and want to make it available to others, please modify the README and open a PR.
+
+

--- a/autosetup.sh
+++ b/autosetup.sh
@@ -12,9 +12,9 @@ echo "putting your hostname ($1) into nginx-reverse-proxy"
 cat nginx-reverse-proxy | sed "s/yourhost/$1/g" > nginx-reverse-proxy.custom
 
 #automatically copy nginx-reverse-proxy.custom and certs to the right folders
-#echo "next steps will require sudo as nginx folder is owned by root (somehow)"
-#echo "copying your reverse proxy conf to /etc/nginx/sites-enabled/$1"
-#sudo cp nginx-reverse-proxy.custom /etc/nginx/sites-enabled/$1
-#echo "putting nerdz certs into nginx folders..."
-#sudo mkdir -p /etc/nginx/ssl
-#sudo cp nginx/conf/certs/nerdz.* /etc/nginx/ssl
+echo "next steps will require sudo as nginx folder is owned by root (somehow)"
+echo "copying your reverse proxy conf to /etc/nginx/sites-enabled/$1"
+sudo cp nginx-reverse-proxy.custom /etc/nginx/sites-enabled/$1
+echo "putting nerdz certs into nginx folders..."
+sudo mkdir -p /etc/nginx/ssl
+sudo cp nginx/conf/certs/nerdz.* /etc/nginx/ssl

--- a/autosetup.sh
+++ b/autosetup.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 
 #install docker-compose via pip
+
+echo "installing docker-compose in a virtualenv..."
 virtualenv nerdz_venv
 source nerdz_venv/bin/activate
-pip install --upgrade docker-compose
+pip install docker-compose
 
 #replace server_name in nginx-reverse-proxy with your server
+echo "putting your hostname ($1) into nginx-reverse-proxy"
 cat nginx-reverse-proxy | sed "s/yourhost/$1/g" > nginx-reverse-proxy.custom
+
+#automatically copy nginx-reverse-proxy.custom and certs to the right folders
+#echo "next steps will require sudo as nginx folder is owned by root (somehow)"
+#echo "copying your reverse proxy conf to /etc/nginx/sites-enabled/$1"
+#sudo cp nginx-reverse-proxy.custom /etc/nginx/sites-enabled/$1
+#echo "putting nerdz certs into nginx folders..."
+#sudo mkdir -p /etc/nginx/ssl
+#sudo cp nginx/conf/certs/nerdz.* /etc/nginx/ssl

--- a/autosetup.sh
+++ b/autosetup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#install docker-compose via pip
+virtualenv nerdz_venv
+source nerdz_venv/bin/activate
+pip install --upgrade docker-compose
+
+#replace server_name in nginx-reverse-proxy with your server
+cat nginx-reverse-proxy | sed "s/yourhost/$1/g" > nginx-reverse-proxy.custom

--- a/autosetup.sh
+++ b/autosetup.sh
@@ -12,9 +12,10 @@ echo "putting your hostname ($1) into nginx-reverse-proxy"
 cat nginx-reverse-proxy | sed "s/yourhost/$1/g" > nginx-reverse-proxy.custom
 
 #automatically copy nginx-reverse-proxy.custom and certs to the right folders
-echo "next steps will require sudo as nginx folder is owned by root (somehow)"
-echo "copying your reverse proxy conf to /etc/nginx/sites-enabled/$1"
-sudo cp nginx-reverse-proxy.custom /etc/nginx/sites-enabled/$1
-echo "putting nerdz certs into nginx folders..."
-sudo mkdir -p /etc/nginx/ssl
-sudo cp nginx/conf/certs/nerdz.* /etc/nginx/ssl
+#echo "next steps will require sudo as nginx folder is owned by root (somehow)"
+#echo "copying your reverse proxy conf to /etc/nginx/sites-enabled/$1"
+#sudo cp nginx-reverse-proxy.custom /etc/nginx/sites-enabled/$1
+#echo "putting nerdz certs into nginx folders..."
+#sudo mkdir -p /etc/nginx/ssl
+#sudo cp nginx/conf/certs/nerdz.* /etc/nginx/ssl
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ postgres:
     ports:
         - "5432"
     volumes:
-        - postgres/data:/var/lib/postgresql/data
+        - ./postgres/data:/var/lib/postgresql/data
 
 php:
     image: nerdzeu/docker-php
@@ -12,8 +12,8 @@ php:
     links:
         - postgres
     volumes:
-        - php/env:/srv/http
-        - php/conf:/etc/php
+        - ./php/env:/srv/http
+        - ./php/conf:/etc/php
 
 nginx:
     image: nerdzeu/docker-nginx
@@ -25,4 +25,5 @@ nginx:
     volumes_from:
         - php
     volumes:
-        - nginx/conf:/etc/nginx
+        - ./nginx/conf:/etc/nginx
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,10 @@ nginx:
 
 camo:
     image: nerdzeu/docker-camo
+    #build: ./camo
     ports:
         - "8081:8081"
     links:
-        - php
+        - nginx
     volumes:
         - ./camo:/home/camo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,11 @@ nginx:
     volumes:
         - ./nginx/conf:/etc/nginx
 
+camo:
+    image: nerdzeu/docker-camo
+    ports:
+        - "8081:8081"
+    links:
+        - php
+    volumes:
+        - ./camo:/home/camo

--- a/nginx-reverse-proxy
+++ b/nginx-reverse-proxy
@@ -27,6 +27,10 @@ server {
 
 	server_name yourhost;
 
+        ssl on;
+        ssl_certificate /etc/nginx/ssl/nerdz.crt;
+        ssl_certificate_key /etc/nginx/ssl/nerdz.key;
+
 	real_ip_header    X-Real-IP;
 	real_ip_recursive on;
 	client_max_body_size 50M;

--- a/nginx-reverse-proxy
+++ b/nginx-reverse-proxy
@@ -94,3 +94,33 @@ server {
 		proxy_set_header X-Request-Start $msec;
 	}
 }
+
+
+server {
+        listen      [::]:443;
+        listen      443;
+
+        server_name camo.yourhost;
+
+        ssl on;
+        ssl_certificate /etc/nginx/ssl/nerdz.crt;
+        ssl_certificate_key /etc/nginx/ssl/nerdz.key;
+
+        real_ip_header    X-Real-IP;
+        real_ip_recursive on;
+        client_max_body_size 50M;
+
+        location / {
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+                proxy_pass  https://127.0.0.1:8081;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_set_header Host camo.asagi.alfa.moe;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-For $remote_addr;
+                proxy_set_header X-Forwarded-Port $server_port;
+                proxy_set_header X-Request-Start $msec;
+        }
+}
+

--- a/nginx-reverse-proxy
+++ b/nginx-reverse-proxy
@@ -111,12 +111,12 @@ server {
         client_max_body_size 50M;
 
         location / {
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
-                proxy_pass  https://127.0.0.1:8081;
+        #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+		proxy_pass  http://127.0.0.1:8081;
                 proxy_http_version 1.1;
                 proxy_set_header Upgrade $http_upgrade;
                 proxy_set_header Connection "upgrade";
-                proxy_set_header Host camo.asagi.alfa.moe;
+                proxy_set_header Host camo.yourhost;
                 proxy_set_header X-Forwarded-Proto $scheme;
                 proxy_set_header X-Forwarded-For $remote_addr;
                 proxy_set_header X-Forwarded-Port $server_port;


### PR DESCRIPTION
SSL and camo are now available out of the box. Configuration docs are available in the readme.

SSL: adding `ssl on;` and `ssl_certificate_*` directives just works. Nerdz' self-signed certificates have been used during testing. I did not try if it works with cloudflare, though.

camo: it's just an HTTP proxy to an internal service listening on port 8081. `ssl` directives are needed as we want to serve content via HTTPS.
